### PR TITLE
Add necessary include to Camera.h (fix)

### DIFF
--- a/Raytracer/include/Camera.h
+++ b/Raytracer/include/Camera.h
@@ -2,6 +2,7 @@
 
 #include "Vec3f.h"
 #include "Constants.h"
+#include "Ray.h"
 
 class Camera
 {


### PR DESCRIPTION
Now the translation unit `Main.cpp` is compiling without errors because `Ray.h` is included before `Camera.h` as shown below:

https://github.com/Paul-Llamoja-Sarmiento/Simple-RayTracer/blob/3c62421cfbe364ca40b42f4af17fbd196672079a/Raytracer/src/Main.cpp#L1-L9

But if `Camera.h` is included into another translation unit, that translation unit won't compile successfully.